### PR TITLE
Referencing this:  Cannot initialize router when used via CommonJS #332

### DIFF
--- a/src/start-router.js
+++ b/src/start-router.js
@@ -1,4 +1,4 @@
-import {Router} from 'director';
+import { Router } from 'director/build/director';
 import {autorun} from 'mobx';
 import {viewsForDirector} from './utils';
 

--- a/src/start-router.js
+++ b/src/start-router.js
@@ -1,4 +1,4 @@
-import { Router } from 'director/build/director';
+import {Router} from 'director/build/director';
 import {autorun} from 'mobx';
 import {viewsForDirector} from './utils';
 


### PR DESCRIPTION
I wasn't able to get mobx-router to run.  However, when making the change suggested in this [thread](https://github.com/flatiron/director/issues/332) it worked fine.