### PR TITLE
Using observer to inject stores is deprecated

### DIFF
--- a/src/components/MobxRouter.js
+++ b/src/components/MobxRouter.js
@@ -1,5 +1,5 @@
 import React, {Component} from 'react';
-import {observer} from 'mobx-react';
+import {observer, inject} from 'mobx-react';
 
 const MobxRouter = ({store:{router}}) => <div>{router.currentView && router.currentView.component}</div>;
-export default observer(['store'], MobxRouter);
+export default inject('store')(observer(MobxRouter));


### PR DESCRIPTION
https://github.com/mobxjs/mobx-react/blob/master/CHANGELOG.md#using-observer-to-inject-stores-is-deprecated

fixed