### PR TITLE
Save original params

### DIFF
--- a/src/router-store.js
+++ b/src/router-store.js
@@ -19,7 +19,7 @@ class RouterStore {
       return;
     }
 
-    const rootViewChanged = !this.currentView || (this.currentView.rootPath !== view.rootPath);
+    const rootViewChanged = !this.currentView || (this.currentView !== view);
     const currentParams = toJS(this.params);
     const currentQueryParams = toJS(this.queryParams);
 
@@ -32,17 +32,21 @@ class RouterStore {
     if (beforeEnterResult === false) {
       return;
     }
+    const nextParams = toJS(paramsObj);
+    const nextQueryParams = toJS(queryParamsObj);
 
     rootViewChanged && this.currentView && this.currentView.onExit && this.currentView.onExit(this.currentView, currentParams, store, currentQueryParams);
+
+    const origParams = toJS(this.params)
+    const origQueryParams = toJS(this.queryParams)
 
     this.currentView = view;
     this.params = toJS(paramsObj);
     this.queryParams = toJS(queryParamsObj);
-    const nextParams = toJS(paramsObj);
-    const nextQueryParams = toJS(queryParamsObj);
 
     rootViewChanged && view.onEnter && view.onEnter(view, nextParams, store, nextQueryParams);
-    !rootViewChanged && this.currentView && this.currentView.onParamsChange && this.currentView.onParamsChange(this.currentView, nextParams, store, nextQueryParams);
+    !rootViewChanged && this.currentView && this.currentView.onParamsChange &&
+      this.currentView.onParamsChange(this.currentView, origParams, store, origQueryParams);
   }
 
   @computed get currentPath() {

--- a/tests/hooks.spec.js
+++ b/tests/hooks.spec.js
@@ -20,14 +20,14 @@ test('Router Scenario', () => {
 
   expect(router.currentPath).toBe('/profile/kristijan');
   expect(mocks.enteringProfile).toHaveBeenCalledTimes(1);
-  expect(mocks.changingParamsProfile).lastCalledWith({username: 'kristijan'}, undefined);
+  expect(mocks.changingParamsProfile).lastCalledWith({username: 'kitze'}, undefined);
   expect(mocks.changingParamsProfile).toHaveBeenCalledTimes(1);
 
   router.goTo(routes.profile, {username: 'kristijan', tab: 'about'});
 
   expect(router.currentPath).toBe('/profile/kristijan/about');
   expect(mocks.enteringProfile).toHaveBeenCalledTimes(1);
-  expect(mocks.changingParamsProfile).lastCalledWith({tab: 'about', username: 'kristijan'}, undefined);
+  expect(mocks.changingParamsProfile).lastCalledWith({username: 'kristijan'}, undefined);
   expect(mocks.changingParamsProfile).toHaveBeenCalledTimes(2);
 
   router.goTo(routes.home);

--- a/tests/query-params.spec.js
+++ b/tests/query-params.spec.js
@@ -20,14 +20,14 @@ test('Router Scenario', () => {
 
   expect(router.currentPath).toBe('/profile/kristijan');
   expect(mocks.enteringProfile).toHaveBeenCalledTimes(1);
-  expect(mocks.changingParamsProfile).lastCalledWith({username: 'kristijan'}, undefined);
+  expect(mocks.changingParamsProfile).lastCalledWith({username: 'kitze'}, {id: 123});
   expect(mocks.changingParamsProfile).toHaveBeenCalledTimes(1);
 
   router.goTo(routes.profile, {username: 'kristijan', tab: 'about'});
 
   expect(router.currentPath).toBe('/profile/kristijan/about');
   expect(mocks.enteringProfile).toHaveBeenCalledTimes(1);
-  expect(mocks.changingParamsProfile).lastCalledWith({tab: 'about', username: 'kristijan'}, undefined);
+  expect(mocks.changingParamsProfile).lastCalledWith({username: 'kristijan'}, undefined);
   expect(mocks.changingParamsProfile).toHaveBeenCalledTimes(2);
 
   router.goTo(routes.home);
@@ -43,7 +43,7 @@ test('Router Scenario', () => {
   router.goTo(routes.profile, {username: 'kristijan', tab: 'about'});
 
   expect(router.currentPath).toBe('/profile/kristijan/about');
-  expect(mocks.changingParamsProfile).lastCalledWith({tab: 'about', username: 'kristijan'}, undefined);
+  expect(mocks.changingParamsProfile).lastCalledWith(undefined, undefined);
   expect(mocks.changingParamsProfile).toHaveBeenCalledTimes(2);
 
   router.goTo(routes.profile, {username: 'kristijan', tab: 'about'});
@@ -55,13 +55,13 @@ test('Router Scenario', () => {
   router.goTo(routes.profile, {username: 'kristijan', tab: 'about'}, null, {id: 123});
 
   expect(router.currentPath).toBe('/profile/kristijan/about?id=123');
-  expect(mocks.changingParamsProfile).lastCalledWith({tab: 'about', username: 'kristijan'}, {id: 123});
+  expect(mocks.changingParamsProfile).lastCalledWith({tab: 'about', username: 'kristijan'}, undefined);
   expect(mocks.changingParamsProfile).toHaveBeenCalledTimes(3);
 
   router.goTo(routes.profile, {username: 'kristijan', tab: 'about'});
 
   expect(router.currentPath).toBe('/profile/kristijan/about');
-  expect(mocks.changingParamsProfile).lastCalledWith({tab: 'about', username: 'kristijan'}, undefined);
+  expect(mocks.changingParamsProfile).lastCalledWith({tab: 'about', username: 'kristijan'}, {id: 123});
   expect(mocks.changingParamsProfile).toHaveBeenCalledTimes(4);
 
 });


### PR DESCRIPTION
On currentView.onParamsChange I would need the previous params, so I would suggest to call the handler with saved params instead next params (which are effectively current, since they has been already set to this.params and this.queryParams).