### PR TITLE
Config for director/Router

### DIFF
--- a/src/start-router.js
+++ b/src/start-router.js
@@ -2,19 +2,20 @@ import { Router } from 'director/build/director';
 import { autorun } from 'mobx';
 import { viewsForDirector } from './utils';
 
-const createDirectorRouter = (views, store) => {
+const createDirectorRouter = (views, store, config) => {
     new Router({
         ...viewsForDirector(views, store)
     })
         .configure({
-            html5history: true
+            html5history: true,
+            ...config
         })
         .init();
 };
 
-export const startRouter = (views, store) => {
+export const startRouter = (views, store, config) => {
     //create director configuration
-    createDirectorRouter(views, store);
+    createDirectorRouter(views, store, config);
 
     //autorun and watch for path changes
     autorun(() => {


### PR DESCRIPTION
Allow passing a config to the `director/Router` instance. In my case I need to catch the trailing slash (`{strict: false}`).