### PR TITLE
Use transaction to update properties currentView, params & queryParams

### DIFF
--- a/src/router-store.js
+++ b/src/router-store.js
@@ -1,4 +1,4 @@
-import { observable, computed, action, toJS } from 'mobx';
+import { observable, computed, action, toJS, transaction } from 'mobx';
 
 export class RouterStore {
     @observable params = {};
@@ -61,9 +61,12 @@ export class RouterStore {
                 nextPath
             );
 
-        this.currentView = view;
-        this.params = toJS(paramsObj);
-        this.queryParams = toJS(queryParamsObj);
+        transaction(() => {
+            this.currentView = view;
+            this.params = toJS(paramsObj);
+            this.queryParams = toJS(queryParamsObj);
+        });
+
         const nextParams = toJS(paramsObj);
         const nextQueryParams = toJS(queryParamsObj);
 


### PR DESCRIPTION
currentView, params & queryParams of router-store properties are used in a mobx computed property (currentPath). If they are not updated together, observers will be notified for each property change
individually causing unexected behavior.

Fixes kitze/mobx-router#68
