### PR TITLE
Fix strict mode from transaction block

### DIFF
--- a/src/router-store.js
+++ b/src/router-store.js
@@ -1,4 +1,4 @@
-import { observable, computed, action, toJS, transaction } from 'mobx';
+import { observable, computed, action, toJS, runInAction } from 'mobx';
 
 export class RouterStore {
     @observable params = {};

--- a/src/router-store.js
+++ b/src/router-store.js
@@ -61,7 +61,7 @@ export class RouterStore {
                 nextPath
             );
 
-        transaction(() => {
+        runInAction(() => {
             this.currentView = view;
             this.params = toJS(paramsObj);
             this.queryParams = toJS(queryParamsObj);


### PR DESCRIPTION
We use strict mode for MobX and when using mobx-router, mutating the currentView within the transaction block is causing it to complain.