### PR TITLE
fix: query parameter disappears on browser reload or jumped from <a> tag

### DIFF
--- a/src/start-router.ts
+++ b/src/start-router.ts
@@ -3,17 +3,14 @@ import { Router } from 'director/build/director';
 
 import { autorun } from 'mobx';
 
-import { viewsForDirector } from './utils';
+import { viewsForDirector, DirectorConfig } from './utils';
 import { RoutesConfig } from './route';
 import { Store } from './router-store';
 
-interface DirectorConfig {
-    html5history?: boolean
-}
 
 const createDirectorRouter = <T extends Store>(views: RoutesConfig<T>, store: T, config: DirectorConfig = {}) => {
     new Router({
-        ...viewsForDirector(views, store)
+        ...viewsForDirector(views, store, config)
     })
         .configure({
             html5history: true,


### PR DESCRIPTION
Thank you for merging https://github.com/kitze/mobx-router/pull/98.
It's working almost fine, but I found query parameters (`?foo=1&bar=2`) disappears when browser is reloaded or jumped from `<a />` tag.
I guess codes for processing query parameter has been mistakenly removed by this commit: https://github.com/kitze/mobx-router/commit/63ec2043ede89debb279049c9807ba317e2d7b86#diff-1d5b61af80d4f2c1f68da211159fe995L152.
I've restored it and also added codes for hash routing case.
Please review, Thanks.